### PR TITLE
feat: Add support for module queries

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -122,7 +122,7 @@ func (c *Cache) download(t tool.Tool) (tool.Tool, error) {
 	modfilePath := filepath.Join(modDir, "go.mod")
 
 	// If we have the version the process is pretty easy
-	if t.Version != "" {
+	if t.HasSemver() {
 		if util.FileOrDirExists(modfilePath) {
 			// If go.mod already exists, make sure there's no issues with it
 			data, err := ioutil.ReadFile(modfilePath)
@@ -177,11 +177,7 @@ func (c *Cache) download(t tool.Tool) (tool.Tool, error) {
 			}
 		}
 
-		// It's easier to just mkdir -p right now instead of
-		// check if the dir exists beforehand
-		// We can improve this later if needed
-		err = os.MkdirAll(modDir, 0o755)
-		if err != nil {
+		if err := os.MkdirAll(modDir, 0o755); err != nil {
 			return t, errors.Wrapf(err, "failed to create directory %q", modDir)
 		}
 
@@ -209,9 +205,8 @@ func (c *Cache) download(t tool.Tool) (tool.Tool, error) {
 	}
 
 	// Don't have the version, this process is a bit more complicated because
-	// we need to figure out what the latest version is
+	// we need to resolve the correct version.
 
-	// Use import path without version and download latest version
 	if err := os.MkdirAll(modDir, 0o755); err != nil {
 		return t, errors.Wrapf(err, "failed to create directory %q", modDir)
 	}
@@ -233,7 +228,7 @@ func (c *Cache) download(t tool.Tool) (tool.Tool, error) {
 	}
 
 	// Download the module source. This will do the heavy lifting to figure out
-	// the latest version.
+	// the correct version.
 	err = c.goClient.GetD(t.Module(), modDir)
 	if err != nil {
 		return t, err

--- a/client/client.go
+++ b/client/client.go
@@ -136,6 +136,7 @@ func (s *Shed) Install(allowUpdates bool, toolNames ...string) error {
 		t, err := tool.ParseLax(toolName)
 		if err != nil {
 			errs = append(errs, errors.WithMessagef(err, "invalid tool name %s", toolName))
+			continue
 		}
 
 		existing, err := s.lf.GetTool(toolName)

--- a/client/client.go
+++ b/client/client.go
@@ -132,7 +132,8 @@ func (s *Shed) Install(allowUpdates bool, toolNames ...string) error {
 	var errs lockfile.ErrorList
 	for _, toolName := range toolNames {
 		// This also serves to validate the the given tool name is a valid module name
-		t, err := tool.Parse(toolName)
+		// Use ParseLax since the version might be a query that should be passed to go get.
+		t, err := tool.ParseLax(toolName)
 		if err != nil {
 			errs = append(errs, errors.WithMessagef(err, "invalid tool name %s", toolName))
 		}

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -38,14 +38,25 @@ func TestClientCache(t *testing.T) {
 	}
 }
 
-var availableTools = []string{
-	"github.com/cszatmary/go-fish@v0.1.0",
-	"github.com/golangci/golangci-lint/cmd/golangci-lint@v1.33.0",
-	"github.com/golangci/golangci-lint/cmd/golangci-lint@v1.28.3",
-	"golang.org/x/tools/cmd/stringer@v0.0.0-20201211185031-d93e913c1a58",
-	"github.com/Shopify/ejson/cmd/ejson@v1.2.2",
-	"github.com/Shopify/ejson/cmd/ejson@v1.1.0",
-	"example.org/z/random/stringer/v2/cmd/stringer@v2.1.0",
+var availableTools = map[string]map[string]string{
+	"github.com/cszatmary/go-fish": {
+		"v0.1.0": "v0.1.0",
+		"22d10c9b658df297b17b33c836a60fb943ef5a5f": "v0.0.0-20201203230243-22d10c9b658d",
+	},
+	"github.com/golangci/golangci-lint/cmd/golangci-lint": {
+		"v1.33.0": "v1.33.0",
+		"v1.28.3": "v1.28.3",
+	},
+	"golang.org/x/tools/cmd/stringer": {
+		"v0.0.0-20201211185031-d93e913c1a58": "v0.0.0-20201211185031-d93e913c1a58",
+	},
+	"github.com/Shopify/ejson/cmd/ejson": {
+		"v1.2.2": "v1.2.2",
+		"v1.1.0": "v1.1.0",
+	},
+	"example.org/z/random/stringer/v2/cmd/stringer": {
+		"v2.1.0": "v2.1.0",
+	},
 }
 
 func createLockfile(t *testing.T, path string, tools []tool.Tool) {
@@ -106,13 +117,13 @@ func TestInstall(t *testing.T) {
 			name:          "install specific versions",
 			lockfileTools: nil,
 			installTools: []string{
-				"github.com/cszatmary/go-fish@v0.1.0",
+				"github.com/cszatmary/go-fish@22d10c9b658df297b17b33c836a60fb943ef5a5f",
 				"github.com/golangci/golangci-lint/cmd/golangci-lint@v1.28.3",
 				"github.com/Shopify/ejson/cmd/ejson@v1.1.0",
 			},
 			allowUpdates: false,
 			wantTools: []tool.Tool{
-				{ImportPath: "github.com/cszatmary/go-fish", Version: "v0.1.0"},
+				{ImportPath: "github.com/cszatmary/go-fish", Version: "v0.0.0-20201203230243-22d10c9b658d"},
 				{ImportPath: "github.com/golangci/golangci-lint/cmd/golangci-lint", Version: "v1.28.3"},
 				{ImportPath: "github.com/Shopify/ejson/cmd/ejson", Version: "v1.1.0"},
 			},

--- a/lockfile/lockfile.go
+++ b/lockfile/lockfile.go
@@ -24,7 +24,7 @@ var ErrIncorrectVersion = errors.New("lockfile: incorrect version of tool")
 var ErrMultipleTools = errors.New("lockfile: multiple tools found with the same name")
 
 // Lockfile represents a shed lockfile. The lockfile is responsible for keeping
-// track of installed tools as well as their versions should shed can always
+// track of installed tools as well as their versions so shed can always
 // re-install the same version of each tool.
 //
 // An a zero value Lockfile is a valid empty lockfile ready for use.
@@ -66,7 +66,7 @@ func (lf *Lockfile) GetTool(name string) (tool.Tool, error) {
 	}
 
 	// Long way, parse the tool name which should be an import path
-	tl, err := tool.Parse(name)
+	tl, err := tool.ParseLax(name)
 	if err != nil {
 		return tool.Tool{}, err
 	}
@@ -92,7 +92,7 @@ func (lf *Lockfile) GetTool(name string) (tool.Tool, error) {
 	return tool.Tool{}, fmt.Errorf("%w: %s", ErrNotFound, toolName)
 }
 
-// PutTool add or replaces the given tool in the lockfile.
+// PutTool adds or replaces the given tool in the lockfile.
 func (lf *Lockfile) PutTool(t tool.Tool) {
 	if lf.tools == nil {
 		lf.tools = make(map[string][]tool.Tool)

--- a/lockfile/lockfile_test.go
+++ b/lockfile/lockfile_test.go
@@ -81,6 +81,13 @@ func TestLockfileGet(t *testing.T) {
 			wantTool: tool.Tool{ImportPath: "golang.org/x/tools/cmd/stringer", Version: "v0.0.0-20201211185031-d93e913c1a58"},
 			wantErr:  lockfile.ErrIncorrectVersion,
 		},
+		{
+			// Make sure it is not found instead of invalid version
+			name:     "not found query",
+			toolName: "golang.org/x/tools/cmd/stress@master",
+			wantTool: tool.Tool{},
+			wantErr:  lockfile.ErrNotFound,
+		},
 	}
 
 	for _, tt := range tests {

--- a/tool/tool.go
+++ b/tool/tool.go
@@ -3,11 +3,11 @@
 package tool
 
 import (
+	"fmt"
 	"path"
 	"path/filepath"
 	"strings"
 
-	"github.com/pkg/errors"
 	"golang.org/x/mod/module"
 	"golang.org/x/mod/semver"
 )
@@ -43,6 +43,11 @@ func (t Tool) Module() string {
 	return t.ImportPath + "@" + t.Version
 }
 
+// HasSemver reports whether t.Version is a valid semantic version.
+func (t Tool) HasSemver() bool {
+	return semver.IsValid(t.Version)
+}
+
 // String returns a string representation of the tool.
 func (t Tool) String() string {
 	// While this may seem shallow, String serves a different purpose
@@ -59,13 +64,13 @@ func (t Tool) String() string {
 func (t Tool) Filepath() (string, error) {
 	escapedPath, err := module.EscapePath(t.ImportPath)
 	if err != nil {
-		return "", errors.Wrapf(err, "tool: failed to escape path %q", t.ImportPath)
+		return "", fmt.Errorf("tool: failed to escape path %q: %w", t.ImportPath, err)
 	}
 
 	if t.Version != "" {
 		escapedVersion, err := module.EscapeVersion(t.Version)
 		if err != nil {
-			return "", errors.Wrapf(err, "tool: failed to escape version %q", t.Version)
+			return "", fmt.Errorf("tool: failed to escape version %q: %w", t.Version, err)
 		}
 		escapedPath += "@" + escapedVersion
 	}
@@ -78,31 +83,55 @@ func (t Tool) Filepath() (string, error) {
 func (t Tool) BinaryFilepath() (string, error) {
 	fp, err := t.Filepath()
 	if err != nil {
-		return "", errors.WithMessage(err, "tool: failed to get filepath")
+		return "", err
 	}
 	return filepath.Join(fp, t.Name()), nil
 }
 
 // Parse parses the given tool name. Name must be a valid import path,
-// optionally with a version. If a version is provided, the format must be
-// 'ImportPath@Version', just like what would be passed to a command like 'go get'.
+// optionally with a version. If a version is provided, it must be a valid
+// semantic version and it must be prefixed with 'v' (ex: 'v1.2.3').
+// The format with a version must be 'ImportPath@Version', just like
+// what would be passed to a command like 'go get'.
 func Parse(name string) (Tool, error) {
+	return parseTool(name, true)
+}
+
+// ParseLax is like Parse but does not check that the version is a valid semantic version.
+// It is used when downloading and resolving tools using 'go get'. This is because
+// go get allows module queries, which is where a version is resolved based on a
+// branch name, commit SHA, version range, etc.
+// See https://golang.org/cmd/go/#hdr-Module_queries for more details.
+func ParseLax(name string) (Tool, error) {
+	return parseTool(name, false)
+}
+
+func parseTool(name string, strict bool) (Tool, error) {
 	t := Tool{ImportPath: name}
 
-	// Check if version is provided
+	// Check if a version/query is provided
 	if i := strings.IndexByte(name, '@'); i != -1 {
 		t.ImportPath = name[:i]
 		t.Version = name[i+1:]
+
+		// Make sure there isn't a dangling '@'
+		if t.Version == "" {
+			return t, fmt.Errorf("tool: missing version after '@'")
+		}
 	}
 
 	// Validations
 	if err := module.CheckPath(t.ImportPath); err != nil {
-		return t, errors.Wrapf(err, "tool: invalid import path: %q", t.ImportPath)
+		return t, fmt.Errorf("tool: invalid import path %q: %w", t.ImportPath, err)
+	}
+	// TODO(@cszatmary): Consider making it an error if version isn't provided
+	// in strict mode.
+	if !strict || t.Version == "" {
+		return t, nil
 	}
 
-	if t.Version != "" && !semver.IsValid(t.Version) {
-		return t, errors.Errorf("tool: invalid version: %q", t.Version)
+	if !semver.IsValid(t.Version) {
+		return t, fmt.Errorf("tool: invalid version %q: not a semantic version", t.Version)
 	}
-
 	return t, nil
 }

--- a/tool/tool_test.go
+++ b/tool/tool_test.go
@@ -115,6 +115,16 @@ func TestToolHasSemver(t *testing.T) {
 			tool: tool.Tool{ImportPath: "golang.org/x/tools/cmd/stringer", Version: "v0.0.0-20201211185031-d93e913c1a58"},
 			want: true,
 		},
+		{
+			name: "shorthand major",
+			tool: tool.Tool{ImportPath: "github.com/golangci/golangci-lint/cmd/golangci-lint", Version: "v1"},
+			want: false,
+		},
+		{
+			name: "shorthand major minor",
+			tool: tool.Tool{ImportPath: "github.com/Shopify/ejson/cmd/ejson", Version: "v1.2"},
+			want: false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -178,11 +188,6 @@ func TestParse(t *testing.T) {
 			want:   tool.Tool{ImportPath: "github.com/cszatmary/go-fish", Version: "v0.1.0"},
 		},
 		{
-			name:   "no version",
-			module: "github.com/cszatmary/go-fish",
-			want:   tool.Tool{ImportPath: "github.com/cszatmary/go-fish"},
-		},
-		{
 			name:   "nested import path",
 			module: "github.com/golangci/golangci-lint/cmd/golangci-lint@v1.33.0",
 			want:   tool.Tool{ImportPath: "github.com/golangci/golangci-lint/cmd/golangci-lint", Version: "v1.33.0"},
@@ -196,6 +201,16 @@ func TestParse(t *testing.T) {
 			name:   "escaped path",
 			module: "github.com/Shopify/ejson/cmd/ejson@v1.2.2",
 			want:   tool.Tool{ImportPath: "github.com/Shopify/ejson/cmd/ejson", Version: "v1.2.2"},
+		},
+		{
+			name:   "shorthand major",
+			module: "github.com/golangci/golangci-lint/cmd/golangci-lint@v1",
+			want:   tool.Tool{ImportPath: "github.com/golangci/golangci-lint/cmd/golangci-lint", Version: "v1.0.0"},
+		},
+		{
+			name:   "shorthand major minor",
+			module: "github.com/Shopify/ejson/cmd/ejson@v1.2",
+			want:   tool.Tool{ImportPath: "github.com/Shopify/ejson/cmd/ejson", Version: "v1.2.0"},
 		},
 	}
 
@@ -224,6 +239,10 @@ func TestParseError(t *testing.T) {
 		{
 			name:   "invalid version",
 			module: "golang.org/x/tools/cmd/stringer@v0..0-20201211185031-d93e913c1a58",
+		},
+		{
+			name:   "no version",
+			module: "github.com/cszatmary/go-fish",
 		},
 		{
 			name:   "dangling @",
@@ -289,6 +308,16 @@ func TestParseLax(t *testing.T) {
 			name:   "git SHA",
 			module: "github.com/cszatmary/go-fish@22d10c9b658df297b17b33c836a60fb943ef5a5f",
 			want:   tool.Tool{ImportPath: "github.com/cszatmary/go-fish", Version: "22d10c9b658df297b17b33c836a60fb943ef5a5f"},
+		},
+		{
+			name:   "shorthand major",
+			module: "github.com/golangci/golangci-lint/cmd/golangci-lint@v1",
+			want:   tool.Tool{ImportPath: "github.com/golangci/golangci-lint/cmd/golangci-lint", Version: "v1"},
+		},
+		{
+			name:   "shorthand major minor",
+			module: "github.com/Shopify/ejson/cmd/ejson@v1.2",
+			want:   tool.Tool{ImportPath: "github.com/Shopify/ejson/cmd/ejson", Version: "v1.2"},
 		},
 	}
 


### PR DESCRIPTION
* `Shed.Install` now supports module queries which are passed to go get.
* Added `tool.ParseLax` which is similar to `tool.Parse` but doesn't check if the version is a valid semver.
* `tool.Parse` now requires version to be set and it must be strict semver.