### PR TITLE
feat!: Change shed and cache constructors to use functional options

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -15,9 +15,7 @@ import (
 
 func TestClientCache(t *testing.T) {
 	td := t.TempDir()
-	s, err := client.NewShed(client.Options{
-		CacheDir: td,
-	})
+	s, err := client.NewShed(client.WithCache(cache.New(td)))
 	if err != nil {
 		t.Fatalf("failed to create shed client %v", err)
 	}
@@ -176,11 +174,10 @@ func TestInstall(t *testing.T) {
 			if tt.lockfileTools != nil {
 				createLockfile(t, lockfilePath, tt.lockfileTools)
 			}
-			s, err := client.NewShed(client.Options{
-				LockfilePath: lockfilePath,
-				CacheDir:     td,
-				Go:           mockGo,
-			})
+			s, err := client.NewShed(
+				client.WithLockfilePath(lockfilePath),
+				client.WithCache(cache.New(td, cache.WithGo(mockGo))),
+			)
 			if err != nil {
 				t.Fatalf("failed to create shed client %v", err)
 			}
@@ -220,11 +217,10 @@ func TestInstallError(t *testing.T) {
 	createLockfile(t, lockfilePath, []tool.Tool{
 		{ImportPath: "github.com/Shopify/ejson/cmd/ejson", Version: "v1.1.0"},
 	})
-	s, err := client.NewShed(client.Options{
-		LockfilePath: lockfilePath,
-		CacheDir:     td,
-		Go:           mockGo,
-	})
+	s, err := client.NewShed(
+		client.WithLockfilePath(lockfilePath),
+		client.WithCache(cache.New(td, cache.WithGo(mockGo))),
+	)
 	if err != nil {
 		t.Fatalf("failed to create shed client %v", err)
 	}
@@ -253,10 +249,10 @@ func TestUninstall(t *testing.T) {
 		{ImportPath: "github.com/golangci/golangci-lint/cmd/golangci-lint", Version: "v1.33.0"},
 		{ImportPath: "github.com/Shopify/ejson/cmd/ejson", Version: "v1.2.2"},
 	})
-	s, err := client.NewShed(client.Options{
-		LockfilePath: lockfilePath,
-		CacheDir:     td,
-	})
+	s, err := client.NewShed(
+		client.WithLockfilePath(lockfilePath),
+		client.WithCache(cache.New(td)),
+	)
 	if err != nil {
 		t.Fatalf("failed to create shed client %v", err)
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -35,9 +35,7 @@ var rootCmd = &cobra.Command{
 		})
 
 		var err error
-		shed, err = client.NewShed(client.Options{
-			Logger: logger,
-		})
+		shed, err = client.NewShed(client.WithLogger(logger))
 		if err != nil {
 			fatal.ExitErrf(err, "Failed to setup shed")
 		}

--- a/lockfile/lockfile.go
+++ b/lockfile/lockfile.go
@@ -27,7 +27,7 @@ var ErrMultipleTools = errors.New("lockfile: multiple tools found with the same 
 // track of installed tools as well as their versions so shed can always
 // re-install the same version of each tool.
 //
-// An a zero value Lockfile is a valid empty lockfile ready for use.
+// A zero value Lockfile is a valid empty lockfile ready for use.
 type Lockfile struct {
 	// tools stores the tools managed by this lockfile. Tools are stored
 	// as a map of tool names to buckets of tools with that name.

--- a/tool/tool.go
+++ b/tool/tool.go
@@ -22,7 +22,7 @@ type Tool struct {
 	ImportPath string
 	// The version of the tool. This correspeonds to the version of
 	// the Go module the tool belongs to. If version is empty,
-	// it significes that the latest version is desired where allowed.
+	// it signifies that the latest version is desired where allowed.
 	Version string
 }
 
@@ -34,7 +34,7 @@ func (t Tool) Name() string {
 
 // Module returns the module name suitable for commands like 'go get'.
 // This is the import path plus the version, if it exists, with the
-// format 'ImportPath@Version'. If Version is empty, Module just
+// format 'IMPORT_PATH@VERSION'. If Version is empty, Module just
 // returns ImportPath.
 func (t Tool) Module() string {
 	if t.Version == "" {
@@ -61,7 +61,7 @@ func (t Tool) String() string {
 }
 
 // Filepath returns the relative OS filesystem path represented by this tool.
-// The escape rules required for import paths on are followed.
+// The escape rules required for import paths are followed.
 // For details on escaped paths see:
 // https://pkg.go.dev/golang.org/x/mod@v0.4.0/module#hdr-Escaped_Paths
 func (t Tool) Filepath() (string, error) {
@@ -94,7 +94,7 @@ func (t Tool) BinaryFilepath() (string, error) {
 // Parse parses the given tool name and returns a tool containing the
 // import path and version. name must be a valid import path and a version
 // with the format 'IMPORT_PATH@VERSION'. This format is the same as what would be
-// pass to a command like 'go get'. The version must be a valid semantic version
+// passed to a command like 'go get'. The version must be a valid semantic version
 // and it must be prefixed with 'v' (ex: 'v1.2.3'). If a shorthand semantic version
 // is used, it will be canonicalized (ex: 'v1' will become 'v1.0.0').
 func Parse(name string) (Tool, error) {


### PR DESCRIPTION
BREAKING CHANGE: The signatures for client.NewShed and cache.New have changed.