### PR TITLE
feat: Find lockfile in parent directories, add init command

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -1,0 +1,45 @@
+package cmd
+
+import (
+	"os"
+
+	"github.com/getshiphub/shed/client"
+	"github.com/getshiphub/shed/internal/util"
+	"github.com/getshiphub/shed/lockfile"
+	"github.com/spf13/cobra"
+)
+
+var initCmd = &cobra.Command{
+	Use:   "init",
+	Args:  cobra.NoArgs,
+	Short: "Generate a lockfile in the current directory.",
+	Long: `shed init initializes shed in the current directory by creating a lockfile.
+In most cases this isn't necessary as shed will automatically create a lockfile when shed install is run.
+
+In some situations however, it may be desirable to explicitly create the lockfile. One reason for this is to
+setup shed in a subdirectory of a project. shed will automatically check parent directories for lockfiles.
+If you wish to have shed install update a lockfile in a subdirectory instead of a parent directory,
+you can use shed init to create a new lockfile.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		logger := newLogger()
+		if util.FileOrDirExists(client.LockfileName) {
+			logger.Infof("%s already exists", client.LockfileName)
+			return
+		}
+
+		f, err := os.OpenFile(client.LockfileName, os.O_WRONLY|os.O_CREATE, 0o644)
+		if err != nil {
+			fatal.ExitErrf(err, "Failed to create file %s", client.LockfileName)
+		}
+		defer f.Close()
+		var lf lockfile.Lockfile
+		if _, err = lf.WriteTo(f); err != nil {
+			fatal.ExitErrf(err, "Failed to write lockfile")
+		}
+		logger.Infof("Created %s", client.LockfileName)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(initCmd)
+}

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -52,6 +52,7 @@ Install all tools specified in shed.lock:
 	shed install`,
 	Run: func(cmd *cobra.Command, args []string) {
 		logger := newLogger()
+		setwd(logger)
 		shed := mustShed(client.WithLogger(logger))
 		installSet, err := shed.Install(installOpts.allowUpdates, args...)
 		if err != nil {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -70,22 +70,22 @@ func newLogger() *logrus.Logger {
 	}
 }
 
-// setwd finds the nearest shed lockfile in either the current directory or parent directories
-// and changes the current working directory.
+// setwd finds the nearest shed lockfile in either the current directory
+// or parent directories and changes the current working directory.
 func setwd(logger *logrus.Logger) {
-	// Find the nearest shed lockfile and change the current directory
-	// This way shed can still work if it's run in a subdirectory of a project
 	cwd, err := os.Getwd()
 	if err != nil {
 		fatal.ExitErrf(err, "Failed to get current working directory")
 	}
 	lfp := client.ResolveLockfilePath(cwd)
-	if lfp != "" {
-		logger.Debugf("Found lockfile: %s", lfp)
-		dir := filepath.Dir(lfp)
-		if err := os.Chdir(dir); err != nil {
-			fatal.ExitErrf(err, "Failed to change current working directory to %s", dir)
-		}
-		logger.Debugf("Changed current working directory to %s", dir)
+	if lfp == "" {
+		return
 	}
+
+	logger.Debugf("Found lockfile: %s", lfp)
+	dir := filepath.Dir(lfp)
+	if err := os.Chdir(dir); err != nil {
+		fatal.ExitErrf(err, "Failed to change current working directory to %s", dir)
+	}
+	logger.Debugf("Changed current working directory to %s", dir)
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"os"
+	"path/filepath"
 
 	"github.com/getshiphub/shed/client"
 	"github.com/getshiphub/shed/internal/util"
@@ -66,5 +67,25 @@ func newLogger() *logrus.Logger {
 		},
 		Hooks: make(logrus.LevelHooks),
 		Level: level,
+	}
+}
+
+// setwd finds the nearest shed lockfile in either the current directory or parent directories
+// and changes the current working directory.
+func setwd(logger *logrus.Logger) {
+	// Find the nearest shed lockfile and change the current directory
+	// This way shed can still work if it's run in a subdirectory of a project
+	cwd, err := os.Getwd()
+	if err != nil {
+		fatal.ExitErrf(err, "Failed to get current working directory")
+	}
+	lfp := client.ResolveLockfilePath(cwd)
+	if lfp != "" {
+		logger.Debugf("Found lockfile: %s", lfp)
+		dir := filepath.Dir(lfp)
+		if err := os.Chdir(dir); err != nil {
+			fatal.ExitErrf(err, "Failed to change current working directory to %s", dir)
+		}
+		logger.Debugf("Changed current working directory to %s", dir)
 	}
 }

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 
+	"github.com/getshiphub/shed/client"
 	"github.com/getshiphub/shed/lockfile"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -29,7 +30,9 @@ Or:
 	shed run golang.org/x/tools/cmd/stringer -- -type=Pill`,
 	Run: func(cmd *cobra.Command, args []string) {
 		toolName := args[0]
-		shed := mustShed()
+		logger := newLogger()
+		setwd(logger)
+		shed := mustShed(client.WithLogger(logger))
 		binPath, err := shed.ToolPath(toolName)
 		if errors.Is(err, lockfile.ErrNotFound) {
 			fatal.Exitf("No tool named %s installed. Run 'shed install' first to install the tool.", toolName)
@@ -39,7 +42,6 @@ Or:
 			fatal.ExitErrf(err, "Failed to run tool %s", toolName)
 		}
 
-		logger := newLogger()
 		logger.WithFields(logrus.Fields{
 			"tool": toolName,
 			"path": binPath,

--- a/cmd/uninstall.go
+++ b/cmd/uninstall.go
@@ -33,6 +33,7 @@ Or:
 		})
 		logger := newLogger()
 		logger.Out = s
+		setwd(logger)
 		shed := mustShed(client.WithLogger(logger))
 		s.Start()
 


### PR DESCRIPTION
* The `install`, `uninstall`, and `run` commands will now search parent directories to find a `shed.lock` if none is found in the current directory. This allows shed to be run in a subdirectory of a project. shed will change the current working directory to the directory that the lockfile is located in.
* `shed init` command was added to create a new `shed.lock` file in the current directory. This allows for creating a new lockfile in a subdirectory as running `shed install` would update the lockfile in the parent directory.