### PR TITLE
feat!: Stop parsing flags after tool name in shed run

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,7 @@ jobs:
           command: make build-snapshot
       - run:
           name: Run tests
-          command: make test-ci
+          command: make test
 
 workflows:
   lint-build-test:

--- a/.hooks/pre-commit
+++ b/.hooks/pre-commit
@@ -8,5 +8,5 @@ shed() {
 }
 
 if GO_FILES="$(git diff --name-only --staged --diff-filter=ACMR | grep "\.go$")"; then
-    shed run goimports -- -w $GO_FILES && git add $GO_FILES
+    shed run goimports -w $GO_FILES && git add $GO_FILES
 fi

--- a/README.md
+++ b/README.md
@@ -66,11 +66,11 @@ Or
 shed run github.com/golangci/golangci-lint/cmd/golangci-lint run
 ```
 
-All additional arguments are passed to the tool being run. If you wish to pass flags to the tool, you must
-put `--` before any flags to indicate that the flags are for the tool and not shed itself.
+All additional arguments are passed to the tool being run. Any flags after the tool name are passed to the
+tool directly and are not parsed by shed.
 
 ```
-shed run stringer -- -type=Pill
+shed run stringer -type=Pill
 ```
 
 ## `shed.lock`

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -18,16 +18,18 @@ var runCmd = &cobra.Command{
 	Long: `shed run runs an installed tool passing all arguments to it.
 
 The tool name can either be the full import path or the binary name if it is unique.
-In order to pass flags to the tool, you must preceed them with '--'. This signifies to
-shed that these flags are meant to be treated as arguments for the tool, and not flags for shed.
+All arguments after the tool name will be passed to the tool as is, even if they are flags.
+That is, 'shed run --verbose foo' is treated differently than 'shed run foo --verbose'.
+The first treats the '--verbose' flag as belonging to shed, the second treats it as belonging
+to the 'foo' tool.
 
 For example to run the stringer tool you can either run:
 
-	shed run stringer -- -type=Pill
+	shed run stringer -type=Pill
 
 Or:
 
-	shed run golang.org/x/tools/cmd/stringer -- -type=Pill`,
+	shed run golang.org/x/tools/cmd/stringer -type=Pill`,
 	Run: func(cmd *cobra.Command, args []string) {
 		toolName := args[0]
 		logger := newLogger()
@@ -62,5 +64,8 @@ Or:
 }
 
 func init() {
+	// Stop parsing flags after first non-flag arg
+	// so we can pass them to the command being run
+	runCmd.Flags().SetInterspersed(false)
 	rootCmd.AddCommand(runCmd)
 }

--- a/scripts/check_fmt.sh
+++ b/scripts/check_fmt.sh
@@ -6,10 +6,8 @@ shed() {
     go run main.go "$@"
 }
 
-if [ "$(shed run goimports -- -l . | wc -l)" -gt 0 ]; then
-    echo "Unformatted files found:"
-    # Run again to print files. Couldn't figure out a way to
-    # save the output and make it work with wc.
-    shed run goimports -- -l .
+files="$(shed run goimports -l .)"
+if [ -n "$files" ]; then
+    printf "Unformatted files found:\n%s\n" "$files"
     exit 1
 fi


### PR DESCRIPTION
`shed run` no longer parses flags after the tool name. Previously flags were allowed to occur anywhere so shed couldn't tell which flags were meant for shed, and which ones were meant for the tool. As a result, `--` had to be used before tool flags which lead to a clumsy experience, ex: `shed run stringer -- -type=Pill`.

Now `shed run` will stop parsing flags after the first non-flag argument, i.e. the tool name. So the previous example would now be `shed run stringer -type=Pill`.