### PR TITLE
feat!: Rename shed install to shed get

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ setup: ## Install all dependencies
 	@go mod tidy
 # Self-hoisted!
 	@echo Installing tool dependencies
-	@$(SHED) install
+	@$(SHED) get
 	@$(SHED) run go-fish install
 .PHONY: setup
 

--- a/README.md
+++ b/README.md
@@ -34,19 +34,25 @@ go get github.com/getshiphub/shed
 shed uses the import path with an optional version to install tools, just like `go get` in module mode.
 
 ```
-shed install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.33.0
+shed get github.com/golangci/golangci-lint/cmd/golangci-lint@v1.33.0
 ```
 
 If the version is omitted, the latest version will be installed.
 
 ```
-shed install github.com/golangci/golangci-lint/cmd/golangci-lint
+shed get github.com/golangci/golangci-lint/cmd/golangci-lint
 ```
 
 If no arguments are provided, shed will install all tools in the `shed.lock` file.
 
 ```
-shed install
+shed get
+```
+
+To uninstall a tool use the special `@none` version suffix.
+
+```
+shed get github.com/golangci/golangci-lint/cmd/golangci-lint@none
 ```
 
 ### Running tools

--- a/client/client.go
+++ b/client/client.go
@@ -143,17 +143,17 @@ func (s *Shed) writeLockfile() error {
 	return nil
 }
 
-// Install computes a set of tools that should be installed. It can be given zero or
+// Get computes a set of tools that should be installed. It can be given zero or
 // more tools as arguments. These will be unioned with the tools in the lockfile
-// to produce a final set of tools to install. Install will return an InstallSet instance
+// to produce a final set of tools to install. Get will return an InstallSet instance
 // which can be used to perform the actual installation.
 //
-// Install does not modify any state, therefore, if you wish to abort the install simply
+// Get does not modify any state, therefore, if you wish to abort the install simply
 // discard the returned InstallSet.
 //
 // All tool names provided must be full import paths, not binary names.
-// If a tool name is invalid, Install will return an error.
-func (s *Shed) Install(toolNames ...string) (*InstallSet, error) {
+// If a tool name is invalid, Get will return an error.
+func (s *Shed) Get(toolNames ...string) (*InstallSet, error) {
 	// Collect all the tools that need to be installed.
 	// Merge the given tools with what exists in the lockfile.
 	seenTools := make(map[string]bool)

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -159,7 +159,7 @@ func readLockfile(t *testing.T, path string) *lockfile.Lockfile {
 	return lf
 }
 
-func TestInstall(t *testing.T) {
+func TestGet(t *testing.T) {
 	tests := []struct {
 		name          string
 		lockfileTools []tool.Tool
@@ -270,7 +270,7 @@ func TestInstall(t *testing.T) {
 				t.Fatalf("failed to create shed client %v", err)
 			}
 
-			installSet, err := s.Install(tt.installTools...)
+			installSet, err := s.Get(tt.installTools...)
 			if err != nil {
 				t.Errorf("want nil error, got %v", err)
 			}
@@ -312,7 +312,7 @@ func TestInstall(t *testing.T) {
 	}
 }
 
-func TestInstallError(t *testing.T) {
+func TestGetError(t *testing.T) {
 	td := t.TempDir()
 	lockfilePath := filepath.Join(td, "shed.lock")
 	mockGo, err := cache.NewMockGo(availableTools)
@@ -331,7 +331,7 @@ func TestInstallError(t *testing.T) {
 		t.Fatalf("failed to create shed client %v", err)
 	}
 
-	_, err = s.Install(
+	_, err = s.Get(
 		"github.com/cszatmary/go-fish",
 		"golangci-lint",
 		"github.com/Shopify/ejson/cmd/ejson@v1.2.2",
@@ -416,7 +416,7 @@ func TestList(t *testing.T) {
 
 			// Install tools, otherwise List might error
 			ctx := context.Background()
-			installSet, err := s.Install()
+			installSet, err := s.Get()
 			if err != nil {
 				t.Fatalf("failed to install tools %v", err)
 			}

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -12,11 +12,11 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var installCmd = &cobra.Command{
-	Use:   "install [tools...]",
+var getCmd = &cobra.Command{
+	Use:   "get [tools...]",
 	Args:  cobra.ArbitraryArgs,
 	Short: "Install Go tools.",
-	Long: `shed install installs the given tools plus all tools specified in a shed.lock file.
+	Long: `shed get installs the given tools plus all tools specified in a shed.lock file.
 After installing the tools, shed will either update the existing shed.lock file in the current directory,
 or create a new shed.lock if one does not exist. The shed.lock file is responsible for keeping track of
 what tools are installed and their verion. This allows shed to always reinstall the same tools.
@@ -33,24 +33,24 @@ Examples:
 
 Install the latest version of a tool:
 
-	shed install golang.org/x/tools/cmd/stringer
+	shed get golang.org/x/tools/cmd/stringer
 
 Install a specific version of a tool:
 
-	shed install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.33.0
+	shed get github.com/golangci/golangci-lint/cmd/golangci-lint@v1.33.0
 
 Install all tools specified in shed.lock:
 
-	shed install
+	shed get
 
 Uninstall a tool:
 
-	shed install golang.org/x/tools/cmd/stringer@none`,
+	shed get golang.org/x/tools/cmd/stringer@none`,
 	Run: func(cmd *cobra.Command, args []string) {
 		logger := newLogger()
 		setwd(logger)
 		shed := mustShed(client.WithLogger(logger))
-		installSet, err := shed.Install(args...)
+		installSet, err := shed.Get(args...)
 		if err != nil {
 			fatal.ExitErrf(err, "Failed to determine list of tools to install")
 		}
@@ -97,5 +97,5 @@ Uninstall a tool:
 }
 
 func init() {
-	rootCmd.AddCommand(installCmd)
+	rootCmd.AddCommand(getCmd)
 }

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -14,11 +14,11 @@ var initCmd = &cobra.Command{
 	Args:  cobra.NoArgs,
 	Short: "Generate a lockfile in the current directory.",
 	Long: `shed init initializes shed in the current directory by creating a lockfile.
-In most cases this isn't necessary as shed will automatically create a lockfile when shed install is run.
+In most cases this isn't necessary as shed will automatically create a lockfile when shed get is run.
 
 In some situations however, it may be desirable to explicitly create the lockfile. One reason for this is to
 setup shed in a subdirectory of a project. shed will automatically check parent directories for lockfiles.
-If you wish to have shed install update a lockfile in a subdirectory instead of a parent directory,
+If you wish to have shed get update a lockfile in a subdirectory instead of a parent directory,
 you can use shed init to create a new lockfile.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		logger := newLogger()

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -37,7 +37,7 @@ Or:
 		shed := mustShed(client.WithLogger(logger))
 		binPath, err := shed.ToolPath(toolName)
 		if errors.Is(err, lockfile.ErrNotFound) {
-			fatal.Exitf("No tool named %s installed. Run 'shed install' first to install the tool.", toolName)
+			fatal.Exitf("No tool named %s installed. Run 'shed get' first to install the tool.", toolName)
 		} else if errors.Is(err, lockfile.ErrMultipleTools) {
 			fatal.Exitf("Multiple tools named %s found. Specify the full import path of the tool in order to run it.", toolName)
 		} else if err != nil {


### PR DESCRIPTION
`shed install` is renamed to `shed get` in order to more closely match `go get`.