### PR TITLE
feat: Refactor CLI implementation, add --progress global flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,11 @@
 SHED = go run main.go
 COVERPKGS = ./cache,./client,./internal/spinner,./internal/util,./lockfile,./tool
 
+ifdef CI
+# Disable spinner in CI
+SHED_GET_ARGS = --progress off
+endif
+
 # Absolutely awesome: http://marmelab.com/blog/2016/02/29/auto-documented-makefile.html
 help:
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
@@ -12,7 +17,7 @@ setup: ## Install all dependencies
 	@go mod tidy
 # Self-hoisted!
 	@echo Installing tool dependencies
-	@$(SHED) get
+	@$(SHED) get $(SHED_GET_ARGS)
 	@$(SHED) run go-fish install
 .PHONY: setup
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,11 @@ You can also install shed using `go get`:
 go get github.com/getshiphub/shed
 ```
 
+Note: Installing from source requires a minimum Go version of 1.16.
+
 ## Usage
+
+shed requires a minimum Go version of `1.11` to be installed. This is because it builds tools from source using Go modules.
 
 ### Installing tools
 

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -189,6 +189,8 @@ func (c *Cache) download(ctx context.Context, t tool.Tool) (tool.Tool, error) {
 				c.logger.Debugf("expected 1 required statement in go.mod, found %d", len(modFile.Require))
 			}
 
+			// TODO(@cszatmary): This blows up if the modfile has 0 require statements, fix this ASAP
+			// Also try to simplify some of the logic in this function if possible
 			mod := modFile.Require[0].Mod
 			// Use contains since actual module could have less then what we are installing
 			// Ex: golang.org/x/tools vs golang.org/x/tools/cmd/stringer

--- a/cmd/cache.go
+++ b/cmd/cache.go
@@ -6,40 +6,33 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var cacheCmd = &cobra.Command{
-	Use:   "cache",
-	Short: "Manage cached tools.",
-	Long: `shed cache manages the cache that contains installed tools.
+func newCacheCommand(c *container) *cobra.Command {
+	cacheCmd := &cobra.Command{
+		Use:   "cache",
+		Short: "Manage cached tools.",
+		Long:  `shed cache manages the cache that contains installed tools.`,
+	}
 
-'shed cache dir' can be used to print the path to the shed cache.
-'shed cache clean' can be used to clean the cache and remove all tools.`,
-}
-
-var cacheCleanCmd = &cobra.Command{
-	Use:   "clean",
-	Short: "Cleans the shed cache.",
-	Long: `Cleans the shed cache by removing all installed tools.
+	cacheCleanCmd := &cobra.Command{
+		Use:   "clean",
+		Short: "Cleans the shed cache.",
+		Long: `Cleans the shed cache by removing all installed tools.
 This is useful for removing any stale tools that are no longer needed.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		shed := mustShed()
-		if err := shed.CleanCache(); err != nil {
-			fatal.ExitErrf(err, "Failed to clean cache directory")
-		}
-	},
-}
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return c.shed.CleanCache()
+		},
+	}
 
-var cacheDirCmd = &cobra.Command{
-	Use:   "dir",
-	Short: "Prints the path to the shed cache directory.",
-	Long:  `Prints the absolute path to the root shed cache directory where tools are installed.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		shed := mustShed()
-		fmt.Println(shed.CacheDir())
-	},
-}
+	cacheDirCmd := &cobra.Command{
+		Use:   "dir",
+		Short: "Prints the path to the shed cache directory.",
+		Long:  `Prints the absolute path to the root shed cache directory where tools are installed.`,
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Println(c.shed.CacheDir())
+		},
+	}
 
-func init() {
 	cacheCmd.AddCommand(cacheCleanCmd)
 	cacheCmd.AddCommand(cacheDirCmd)
-	rootCmd.AddCommand(cacheCmd)
+	return cacheCmd
 }

--- a/cmd/completions.go
+++ b/cmd/completions.go
@@ -7,35 +7,34 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var completionsCmd = &cobra.Command{
-	Use:       "completions <shell>",
-	Args:      cobra.ExactArgs(1),
-	ValidArgs: []string{"bash", "zsh"},
-	Short:     "Generate shell completions.",
-	Long: `shed completions generates a shell completion script and outputs it to standard output.
+func newCompletionsCommand(c *container) *cobra.Command {
+	return &cobra.Command{
+		Use:       "completions <shell>",
+		Args:      cobra.ExactArgs(1),
+		ValidArgs: []string{"bash", "zsh"},
+		Short:     "Generate shell completions.",
+		Long: `shed completions generates a shell completion script and outputs it to standard output.
 Supported shells are: bash, zsh.
 
 For example to generate and use bash completions:
 
 	shed completions bash > /usr/local/etc/bash_completion.d/shed.bash
 	source /usr/local/etc/bash_completion.d/shed.bash`,
-	Run: func(cmd *cobra.Command, args []string) {
-		shell := args[0]
-		var err error
-		switch shell {
-		case "bash":
-			err = rootCmd.GenBashCompletion(os.Stdout)
-		case "zsh":
-			err = rootCmd.GenZshCompletion(os.Stdout)
-		default:
-			err = fmt.Errorf("invalid shell value %q, run 'shed completions --help' to see supported shells", shell)
-		}
-		if err != nil {
-			fatal.ExitErrf(err, "Failed to generate %s completions", shell)
-		}
-	},
-}
-
-func init() {
-	rootCmd.AddCommand(completionsCmd)
+		RunE: func(cmd *cobra.Command, args []string) error {
+			shell := args[0]
+			var err error
+			switch shell {
+			case "bash":
+				err = cmd.Root().GenBashCompletion(os.Stdout)
+			case "zsh":
+				err = cmd.Root().GenZshCompletion(os.Stdout)
+			default:
+				c.exitf(nil, "Invalid shell value %q. Run 'shed completions --help' to see supported shells.", shell)
+			}
+			if err != nil {
+				return fmt.Errorf("failed to generate %s completions: %w", shell, err)
+			}
+			return nil
+		},
+	}
 }

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -1,45 +1,44 @@
 package cmd
 
 import (
+	"errors"
+	"fmt"
 	"os"
 
 	"github.com/getshiphub/shed/client"
-	"github.com/getshiphub/shed/internal/util"
 	"github.com/getshiphub/shed/lockfile"
 	"github.com/spf13/cobra"
 )
 
-var initCmd = &cobra.Command{
-	Use:   "init",
-	Args:  cobra.NoArgs,
-	Short: "Generate a lockfile in the current directory.",
-	Long: `shed init initializes shed in the current directory by creating a lockfile.
+func newInitCommand(c *container) *cobra.Command {
+	return &cobra.Command{
+		Use:   "init",
+		Args:  cobra.NoArgs,
+		Short: "Generate a lockfile in the current directory.",
+		Long: `shed init initializes shed in the current directory by creating a lockfile.
 In most cases this isn't necessary as shed will automatically create a lockfile when shed get is run.
 
 In some situations however, it may be desirable to explicitly create the lockfile. One reason for this is to
 setup shed in a subdirectory of a project. shed will automatically check parent directories for lockfiles.
 If you wish to have shed get update a lockfile in a subdirectory instead of a parent directory,
 you can use shed init to create a new lockfile.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		logger := newLogger()
-		if util.FileOrDirExists(client.LockfileName) {
-			logger.Infof("%s already exists", client.LockfileName)
-			return
-		}
+		RunE: func(cmd *cobra.Command, args []string) error {
+			f, err := os.OpenFile(client.LockfileName, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o644)
+			if errors.Is(err, os.ErrExist) {
+				c.logger.Infof("%s already exists", client.LockfileName)
+				return nil
+			}
+			if err != nil {
+				return fmt.Errorf("failed to create lockfile: %w", err)
+			}
+			defer f.Close()
 
-		f, err := os.OpenFile(client.LockfileName, os.O_WRONLY|os.O_CREATE, 0o644)
-		if err != nil {
-			fatal.ExitErrf(err, "Failed to create file %s", client.LockfileName)
-		}
-		defer f.Close()
-		var lf lockfile.Lockfile
-		if _, err = lf.WriteTo(f); err != nil {
-			fatal.ExitErrf(err, "Failed to write lockfile")
-		}
-		logger.Infof("Created %s", client.LockfileName)
-	},
-}
-
-func init() {
-	rootCmd.AddCommand(initCmd)
+			var lf lockfile.Lockfile
+			if _, err := lf.WriteTo(f); err != nil {
+				return fmt.Errorf("failed to write lockfile: %w", err)
+			}
+			c.logger.Infof("Created %s", client.LockfileName)
+			return nil
+		},
+	}
 }

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -1,22 +1,22 @@
 package cmd
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/getshiphub/shed/client"
 	"github.com/spf13/cobra"
 )
 
-var listOpts struct {
-	showUpdates bool
-}
+func newListCommand(c *container) *cobra.Command {
+	var listOpts struct {
+		showUpdates bool
+	}
 
-var listCmd = &cobra.Command{
-	Use:   "list",
-	Args:  cobra.NoArgs,
-	Short: "List Go tools specified in shed.lock.",
-	Long: `shed list prints a list of tools specified in shed.lock. Each tool will consist of the import path and the version.
+	listCmd := &cobra.Command{
+		Use:   "list",
+		Args:  cobra.NoArgs,
+		Short: "List Go tools specified in shed.lock.",
+		Long: `shed list prints a list of tools specified in shed.lock. Each tool will consist of the import path and the version.
 
 The --upgrades or -u flag causes shed to list information about available upgrades for each tool.
 If a newer version is found for a tool, shed will print it in brackets after the current version.
@@ -24,29 +24,24 @@ If a newer version is found for a tool, shed will print it in brackets after the
 For example, 'shed list -u' might print:
 
 	golang.org/x/tools/cmd/stringer v0.1.0 [v0.1.5]`,
-	Run: func(cmd *cobra.Command, args []string) {
-		logger := newLogger()
-		setwd(logger)
-		shed := mustShed(client.WithLogger(logger))
-		// TODO(@cszatmary): Handle SIGINT
-		tools, err := shed.List(context.Background(), client.ListOptions{
-			ShowUpdates: listOpts.showUpdates,
-		})
-		if err != nil {
-			// TODO(@cszatmary): Improve error handling
-			fatal.ExitErrf(err, "Failed to list tools")
-		}
-		for _, info := range tools {
-			if info.LatestVersion != "" {
-				fmt.Printf("%s %s [%s]\n", info.Tool.ImportPath, info.Tool.Version, info.LatestVersion)
-				continue
+		RunE: func(cmd *cobra.Command, args []string) error {
+			tools, err := c.shed.List(cmd.Context(), client.ListOptions{
+				ShowUpdates: listOpts.showUpdates,
+			})
+			if err != nil {
+				return fmt.Errorf("failed to list tools: %w", err)
 			}
-			fmt.Printf("%s %s\n", info.Tool.ImportPath, info.Tool.Version)
-		}
-	},
-}
+			for _, info := range tools {
+				if info.LatestVersion != "" {
+					fmt.Printf("%s %s [%s]\n", info.Tool.ImportPath, info.Tool.Version, info.LatestVersion)
+					continue
+				}
+				fmt.Printf("%s %s\n", info.Tool.ImportPath, info.Tool.Version)
+			}
+			return nil
+		},
+	}
 
-func init() {
 	listCmd.Flags().BoolVarP(&listOpts.showUpdates, "updates", "u", false, "show latest available version for each tool")
-	rootCmd.AddCommand(listCmd)
+	return listCmd
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,91 +1,187 @@
 package cmd
 
 import (
+	"context"
+	"errors"
+	"fmt"
 	"os"
-	"path/filepath"
+	"os/exec"
+	"os/signal"
+	"regexp"
+	"runtime/debug"
+	"strings"
 
+	"github.com/getshiphub/shed/cache"
 	"github.com/getshiphub/shed/client"
-	"github.com/getshiphub/shed/internal/util"
 	"github.com/mattn/go-isatty"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	"golang.org/x/mod/semver"
 )
 
 // Set by goreleaser when release build is created.
 var version string
 
-type rootOptions struct {
-	verbose bool
-}
-
-var (
-	rootOpts rootOptions
-	fatal    = util.Fatal{}
-)
-
-var rootCmd = &cobra.Command{
-	Use:     "shed",
-	Version: version,
-	Short:   "shed is a CLI for easily managing Go tool dependencies.",
-	PersistentPreRun: func(cmd *cobra.Command, args []string) {
-		fatal.ShowErrorDetail = rootOpts.verbose
-	},
-}
-
-func init() {
-	rootCmd.PersistentFlags().BoolVar(&rootOpts.verbose, "verbose", false, "enable verbose logging")
-}
-
 // Execute runs the shed CLI.
 func Execute() {
-	if err := rootCmd.Execute(); err != nil {
-		fatal.ExitErrf(err, "Failed executing command.")
-	}
-}
+	var c container
+	rootCmd := newRootCommand(&c)
 
-func mustShed(opts ...client.Option) *client.Shed {
-	shed, err := client.NewShed(opts...)
+	// Listen of SIGINT to do a graceful abort
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	abort := make(chan os.Signal, 1)
+	signal.Notify(abort, os.Interrupt)
+	go func() {
+		<-abort
+		cancel()
+	}()
+
+	// Check that go is installed with the minimum required version
+	output, err := exec.CommandContext(ctx, "go", "version").Output()
+	if errors.Is(err, context.Canceled) {
+		fmt.Fprintln(os.Stderr, "\nOperation cancelled")
+		os.Exit(130)
+	}
 	if err != nil {
-		fatal.ExitErrf(err, "Failed to setup shed")
+		c.exitf(err, "Failed to check Go version. Make sure Go 1.11 or later is installed and in your PATH.")
 	}
-	return shed
+	regex := regexp.MustCompile(`go?([0-9]+(?:\.[0-9]+)?(?:\.[0-9]+)?)`)
+	matches := regex.FindSubmatch(output)
+	if len(matches) != 2 {
+		c.exitf(nil, "Unexpected go version format %s, unable to parse", output)
+	}
+	goVersion := string(matches[1])
+	// The semver package requires strings to be prefixed with 'v' to be considered valid
+	if semver.Compare("v"+goVersion, "v1.11") == -1 {
+		c.exitf(nil, "shed requires a minimum Go version of 1.11 to run, current version is %s", goVersion)
+	}
+
+	err = rootCmd.ExecuteContext(ctx)
+	if errors.Is(err, context.Canceled) {
+		fmt.Fprintln(os.Stderr, "\nOperation cancelled")
+		os.Exit(130)
+	}
+	if errors.Is(err, cache.ErrToolNotInstalled) {
+		c.exitf(err, "Tool(s) not installed. Run 'shed get' to install them.")
+	}
+	if err != nil {
+		c.exitf(err, "")
+	}
 }
 
-func newLogger() *logrus.Logger {
-	level := logrus.InfoLevel
-	if rootOpts.verbose {
-		level = logrus.DebugLevel
+// container stores all the dependencies that can be used by commands.
+type container struct {
+	logger *logrus.Logger
+	shed   *client.Shed
+	isaTTY bool
+	opts   struct {
+		verbose      bool
+		progressMode string
+		lockfilePath string
 	}
-	return &logrus.Logger{
-		Out: os.Stderr,
-		Formatter: &logrus.TextFormatter{
-			DisableTimestamp: true,
-			// Need to force colours since the decision of whether or not to use colour
-			// is made lazily the first time a log is written, and Out may be changed
-			// to a spinner before then.
-			ForceColors: isatty.IsTerminal(os.Stderr.Fd()),
+}
+
+// exitf prints the given message to stderr then exits the program.
+// It supports printf like formatting. If err is not nil it is also printed.
+func (c *container) exitf(err error, format string, a ...interface{}) {
+	if err != nil {
+		if c.opts.verbose {
+			fmt.Fprintf(os.Stderr, "Error: %+v\n", err)
+		} else {
+			fmt.Fprintf(os.Stderr, "Error: %s\n", err)
+		}
+	}
+	// If an error was just printed and a message is going to be printed,
+	// add an extra newline inbetween them
+	if err != nil && format != "" {
+		fmt.Fprintln(os.Stderr)
+	}
+	if format != "" {
+		fmt.Fprintf(os.Stderr, format, a...)
+		if !strings.HasSuffix(format, "\n") {
+			fmt.Fprintln(os.Stderr)
+		}
+	}
+	os.Exit(1)
+}
+
+func newRootCommand(c *container) *cobra.Command {
+	// Set version if built from source
+	if version == "" {
+		version = "source"
+		if info, available := debug.ReadBuildInfo(); available {
+			version = info.Main.Version
+		}
+	}
+
+	rootCmd := &cobra.Command{
+		Use:     "shed",
+		Version: version,
+		Short:   "shed is a CLI for easily managing Go tool dependencies.",
+		CompletionOptions: cobra.CompletionOptions{
+			DisableDefaultCmd: true,
 		},
-		Hooks: make(logrus.LevelHooks),
-		Level: level,
-	}
-}
+		// cobra prints errors returned from RunE by default. Disable that since we handle errors ourselves.
+		SilenceErrors: true,
+		// cobra prints command usage by default if RunE returns an error.
+		SilenceUsage: true,
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			var isaTTY bool
+			switch c.opts.progressMode {
+			case "on":
+				isaTTY = true
+			case "off":
+				isaTTY = false
+			case "auto":
+				isaTTY = isatty.IsTerminal(os.Stderr.Fd())
+			default:
+				return fmt.Errorf("invalid progress flag value '%s', valid values are 'on', 'off' or 'auto'", c.opts.progressMode)
+			}
 
-// setwd finds the nearest shed lockfile in either the current directory
-// or parent directories and changes the current working directory.
-func setwd(logger *logrus.Logger) {
-	cwd, err := os.Getwd()
-	if err != nil {
-		fatal.ExitErrf(err, "Failed to get current working directory")
-	}
-	lfp := client.ResolveLockfilePath(cwd)
-	if lfp == "" {
-		return
+			logger := logrus.New()
+			if c.opts.verbose {
+				logger.SetLevel(logrus.DebugLevel)
+			}
+			logger.SetFormatter(&logrus.TextFormatter{
+				DisableTimestamp: true,
+				// Need to force colours since the decision of whether or not to use colour
+				// is made lazily the first time a log is written, and Out may be changed
+				// to a spinner before then.
+				ForceColors: isaTTY,
+			})
+
+			// Find the nearest shed lockfile if it exists
+			cwd, err := os.Getwd()
+			if err != nil {
+				return fmt.Errorf("unable to get current working directory: %w", err)
+			}
+			lfp := client.ResolveLockfilePath(cwd)
+			logger.Debugf("Found lockfile: %s", lfp)
+			shed, err := client.NewShed(client.WithLogger(logger), client.WithLockfilePath(lfp))
+			if err != nil {
+				return fmt.Errorf("failed to setup shed: %w", err)
+			}
+
+			// Set dependencies so commands can use them
+			c.logger = logger
+			c.shed = shed
+			c.isaTTY = isaTTY
+			c.opts.lockfilePath = lfp
+			return nil
+		},
 	}
 
-	logger.Debugf("Found lockfile: %s", lfp)
-	dir := filepath.Dir(lfp)
-	if err := os.Chdir(dir); err != nil {
-		fatal.ExitErrf(err, "Failed to change current working directory to %s", dir)
-	}
-	logger.Debugf("Changed current working directory to %s", dir)
+	rootCmd.AddCommand(
+		newCacheCommand(c),
+		newCompletionsCommand(c),
+		newGetCommand(c),
+		newInitCommand(c),
+		newListCommand(c),
+		newRunCommand(c),
+	)
+
+	rootCmd.PersistentFlags().BoolVar(&c.opts.verbose, "verbose", false, "enable verbose logging")
+	rootCmd.PersistentFlags().StringVar(&c.opts.progressMode, "progress", "auto", "sets if a progress spinner should be used, valid values: on, off, auto")
+	return rootCmd
 }

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -2,20 +2,22 @@ package cmd
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 
-	"github.com/getshiphub/shed/client"
 	"github.com/getshiphub/shed/lockfile"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
-var runCmd = &cobra.Command{
-	Use:   "run <tool> [args...]",
-	Args:  cobra.MinimumNArgs(1),
-	Short: "Run installed tools.",
-	Long: `shed run runs an installed tool passing all arguments to it.
+func newRunCommand(c *container) *cobra.Command {
+	runCmd := &cobra.Command{
+		Use:   "run <tool> [args...]",
+		Args:  cobra.MinimumNArgs(1),
+		Short: "Run installed tools.",
+		Long: `shed run runs an installed tool passing all arguments to it.
 
 The tool name can either be the full import path or the binary name if it is unique.
 All arguments after the tool name will be passed to the tool as is, even if they are flags.
@@ -30,42 +32,41 @@ For example to run the stringer tool you can either run:
 Or:
 
 	shed run golang.org/x/tools/cmd/stringer -type=Pill`,
-	Run: func(cmd *cobra.Command, args []string) {
-		toolName := args[0]
-		logger := newLogger()
-		setwd(logger)
-		shed := mustShed(client.WithLogger(logger))
-		binPath, err := shed.ToolPath(toolName)
-		if errors.Is(err, lockfile.ErrNotFound) {
-			fatal.Exitf("No tool named %s installed. Run 'shed get' first to install the tool.", toolName)
-		} else if errors.Is(err, lockfile.ErrMultipleTools) {
-			fatal.Exitf("Multiple tools named %s found. Specify the full import path of the tool in order to run it.", toolName)
-		} else if err != nil {
-			fatal.ExitErrf(err, "Failed to run tool %s", toolName)
-		}
-
-		logger.WithFields(logrus.Fields{
-			"tool": toolName,
-			"path": binPath,
-		}).Debugf("Found path for tool")
-
-		c := exec.Command(binPath, args[1:]...)
-		c.Stdout = os.Stdout
-		c.Stderr = os.Stderr
-		c.Stdin = os.Stdin
-		if err := c.Run(); err != nil {
-			code := c.ProcessState.ExitCode()
-			if code != -1 {
-				os.Exit(code)
+		RunE: func(cmd *cobra.Command, args []string) error {
+			toolName := args[0]
+			binPath, err := c.shed.ToolPath(toolName)
+			// Handle special cases that are specific to run as they would be difficult for the global error handler to deal with.
+			if errors.Is(err, lockfile.ErrNotFound) {
+				c.exitf(nil, "No tool named %s installed. Run 'shed get' first to install the tool.", toolName)
 			}
-			os.Exit(1)
-		}
-	},
-}
+			if errors.Is(err, lockfile.ErrMultipleTools) {
+				c.exitf(nil, "Multiple tools named %s found. Specify the full import path of the tool in order to run it.", toolName)
+			}
+			if err != nil {
+				return fmt.Errorf("unable to resolve tool %s: %w", toolName, err)
+			}
+			c.logger.WithFields(logrus.Fields{
+				"tool": toolName,
+				"path": binPath,
+			}).Debugf("Found path for tool")
 
-func init() {
-	// Stop parsing flags after first non-flag arg
-	// so we can pass them to the command being run
+			ec := exec.Command(binPath, args[1:]...)
+			ec.Dir = filepath.Dir(c.opts.lockfilePath)
+			ec.Stdout = os.Stdout
+			ec.Stderr = os.Stderr
+			ec.Stdin = os.Stdin
+			if err := ec.Run(); err != nil {
+				code := ec.ProcessState.ExitCode()
+				if code != -1 {
+					os.Exit(code)
+				}
+				os.Exit(1)
+			}
+			return nil
+		},
+	}
+
+	// Stop parsing flags after first non-flag arg so we can pass them to the command being run
 	runCmd.Flags().SetInterspersed(false)
-	rootCmd.AddCommand(runCmd)
+	return runCmd
 }

--- a/internal/spinner/tty.go
+++ b/internal/spinner/tty.go
@@ -2,8 +2,6 @@ package spinner
 
 import (
 	"fmt"
-
-	"github.com/mattn/go-isatty"
 )
 
 // TTYSpinner is a wrapper over a spinner that handles whether or not
@@ -15,16 +13,14 @@ type TTYSpinner struct {
 	isaTTY bool
 }
 
-type fder interface {
-	Fd() uintptr
+type TTYOptions struct {
+	Options
+	IsaTTY bool
 }
 
 // NewTTY creates a new TTYSpinner instance.
-func NewTTY(opts Options) *TTYSpinner {
-	s := &TTYSpinner{Spinner: New(opts)}
-	if f, ok := s.out.(fder); ok {
-		s.isaTTY = isatty.IsTerminal(f.Fd())
-	}
+func NewTTY(opts TTYOptions) *TTYSpinner {
+	s := &TTYSpinner{Spinner: New(opts.Options), isaTTY: opts.IsaTTY}
 	if !s.isaTTY {
 		// Persisting messages isn't allowed if not a tty, since messages
 		// are not erased, and are by definition persisted.

--- a/internal/spinner/tty_test.go
+++ b/internal/spinner/tty_test.go
@@ -9,9 +9,12 @@ import (
 
 func TestTTYSpinner(t *testing.T) {
 	out := &syncBuffer{}
-	s := spinner.NewTTY(spinner.Options{
-		Out:     out,
-		Message: "Cloning repos",
+	s := spinner.NewTTY(spinner.TTYOptions{
+		Options: spinner.Options{
+			Out:     out,
+			Message: "Cloning repos",
+		},
+		IsaTTY: false,
 	})
 	s.Start()
 	s.UpdateMessage("Updating repos")

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -1,10 +1,7 @@
 package util
 
 import (
-	"fmt"
-	"io"
 	"os"
-	"strings"
 )
 
 // FileOrDirExists returns true if the given path exists on the OS filesystem.
@@ -13,52 +10,4 @@ func FileOrDirExists(path string) bool {
 		return false
 	}
 	return true
-}
-
-// Fatal allows for handling fatal conditions in a program.
-// It allows printing error details and then terminating the process.
-type Fatal struct {
-	// ShowErrorDetail controls whether or not errors should be printed
-	// with full detail when ExitErrf is called.
-	ShowErrorDetail bool
-	// ErrWriter is where errors are written.
-	// If not set, it defaults to os.Stderr.
-	ErrWriter io.Writer
-	// ExitFunc is the function called to terminate the program.
-	// This defaults to os.Exit and generally should not be set directly.
-	ExitFunc func(code int)
-}
-
-// ExitErrf prints the given message and error to stderr then exits the program.
-// It supports printf like formatting.
-func (f Fatal) ExitErrf(err error, format string, a ...interface{}) {
-	// Set default values. No need for f to be a pointer receiver because this function
-	// terminates the process, so the modifications don't need to be persisted.
-	if f.ErrWriter == nil {
-		f.ErrWriter = os.Stderr
-	}
-	if f.ExitFunc == nil {
-		f.ExitFunc = os.Exit
-	}
-
-	fmt.Fprintf(f.ErrWriter, format, a...)
-	if !strings.HasSuffix(format, "\n") {
-		fmt.Fprintln(f.ErrWriter)
-	}
-
-	if err != nil {
-		if f.ShowErrorDetail {
-			fmt.Fprintf(f.ErrWriter, "Error: %+v\n", err)
-		} else {
-			fmt.Fprintf(f.ErrWriter, "Error: %s\n", err)
-		}
-	}
-
-	f.ExitFunc(1)
-}
-
-// Exitf prints the given message to stderr then exits the program.
-// It supports printf like formatting.
-func (f Fatal) Exitf(format string, a ...interface{}) {
-	f.ExitErrf(nil, format, a...)
 }

--- a/internal/util/util_test.go
+++ b/internal/util/util_test.go
@@ -1,14 +1,8 @@
 package util_test
 
 import (
-	"bytes"
-	"fmt"
 	"path/filepath"
-	"regexp"
-	"strings"
 	"testing"
-
-	"github.com/pkg/errors"
 
 	"github.com/getshiphub/shed/internal/util"
 )
@@ -32,86 +26,5 @@ func TestFileOrDirExists(t *testing.T) {
 				t.Errorf("got %v, want %v", got, tt.want)
 			}
 		})
-	}
-}
-
-type mockExit struct {
-	code int
-}
-
-func (me *mockExit) Exit(code int) {
-	me.code = code
-}
-
-func TestFatalExitf(t *testing.T) {
-	buf := &bytes.Buffer{}
-	me := mockExit{}
-	fatal := util.Fatal{ErrWriter: buf, ExitFunc: me.Exit}
-
-	fatal.Exitf("%d failures", 3)
-	if me.code != 1 {
-		t.Errorf("got error code %d, expected 1", me.code)
-	}
-	out := buf.String()
-	if out != "3 failures\n" {
-		t.Errorf("got output '%s', expected '3 failures\n'", out)
-	}
-}
-
-func TestExitErrf(t *testing.T) {
-	buf := &bytes.Buffer{}
-	me := mockExit{}
-	fatal := util.Fatal{ErrWriter: buf, ExitFunc: me.Exit}
-
-	err := errors.New("err everything broke")
-	fatal.ExitErrf(err, "%d failures", 3)
-	if me.code != 1 {
-		t.Errorf("got error code %d, expected 1", me.code)
-	}
-	out := buf.String()
-	if out != "3 failures\nError: err everything broke\n" {
-		t.Errorf("got output '%s', expected '3 failures\nError: err everything broke\n'", out)
-	}
-}
-
-func TestExitErrStackf(t *testing.T) {
-	buf := &bytes.Buffer{}
-	me := mockExit{}
-	fatal := util.Fatal{ShowErrorDetail: true, ErrWriter: buf, ExitFunc: me.Exit}
-
-	err := errors.New("err everything broke")
-	fatal.ExitErrf(err, "%d failures", 3)
-	if me.code != 1 {
-		t.Errorf("got error code %d, expected 1", me.code)
-	}
-
-	expected := "3 failures\n" +
-		"Error: err everything broke\n" +
-		"github.com/getshiphub/shed/internal/util_test.TestExitErrStack\n" +
-		"\t.+"
-	testFormatRegexp(t, 0, err, buf.String(), expected)
-}
-
-// Taken from https://github.com/pkg/errors/blob/614d223910a179a466c1767a985424175c39b465/format_test.go#L387
-// Helper to test string with regexp
-func testFormatRegexp(t *testing.T, n int, arg interface{}, format, want string) {
-	t.Helper()
-	got := fmt.Sprintf(format, arg)
-	gotLines := strings.SplitN(got, "\n", -1)
-	wantLines := strings.SplitN(want, "\n", -1)
-
-	if len(wantLines) > len(gotLines) {
-		t.Errorf("test %d: wantLines(%d) > gotLines(%d):\n got: %q\nwant: %q", n+1, len(wantLines), len(gotLines), got, want)
-		return
-	}
-
-	for i, w := range wantLines {
-		match, err := regexp.MatchString(w, gotLines[i])
-		if err != nil {
-			t.Fatal(err)
-		}
-		if !match {
-			t.Errorf("test %d: line %d: fmt.Sprintf(%q, err):\n got: %q\nwant: %q", n+1, i+1, format, got, want)
-		}
 	}
 }


### PR DESCRIPTION
The --progress flag can be used to control whether or not a spinner is
used. Valid values are on, off, and auto.